### PR TITLE
Fix: Add 404.html for GitHub Pages SPA routing

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html itemscope="" itemtype="http://schema.org/WebPage" lang="en">
+<head>
+    <link rel="stylesheet" href="/path/to/folder/css/academicons.min.css"/>
+    <meta http-equiv="content-type" content="text/html;charset=utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta id="viewport" name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="apple-touch-icon" sizes="96x96" href="%PUBLIC_URL%/images/favicon/brazil_network.png">
+    <link rel="icon" type="image/png" sizes="96x96" href="%PUBLIC_URL%/images/favicon/brazil_network.png">
+    <link rel="manifest" href="%PUBLIC_URL%/images/favicon/manifest.json">
+    <meta name="msapplication-TileColor" content="#ffffff">
+    <meta name="msapplication-TileImage" content="%PUBLIC_URL%/images/favicon/brazil_network.png">
+    <meta name="theme-color" content="#ffffff">
+    <link rel="canonical" href="%PUBLIC_URL%/">
+    <link href="//fonts.googleapis.com/css?family=Source+Sans+Pro:400,700|Raleway:400,800,900" rel="stylesheet" async>
+</head>
+
+<body>
+    <div id="root"></div>
+</body>
+
+</html>


### PR DESCRIPTION
Creates a `public/404.html` file, which is a copy of `index.html`. This allows GitHub Pages to correctly serve the React application when a user refreshes or directly accesses a client-side route, preventing 404 errors.