### PR TITLE
Add viewport meta tag for mobile responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>App</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700|Raleway:400,800,900" rel="stylesheet">
 </head>


### PR DESCRIPTION
This change adds the essential viewport meta tag to the index.html file. This tag is critical for responsive design as it instructs mobile browsers to render the site according to the device's width and initial scale, rather than simulating a wider desktop screen. The layout was already using responsive CSS (via the 'skel' mixins), but it was not being triggered on mobile devices because the viewport meta tag was missing. With this change, the site now correctly adapts to different screen sizes.

---
*PR created automatically by Jules for task [15069173302538833669](https://jules.google.com/task/15069173302538833669) started by @vanderfreitas*